### PR TITLE
Add OpenBSD support

### DIFF
--- a/compiledb/commands/make.py
+++ b/compiledb/commands/make.py
@@ -73,6 +73,8 @@ def command(ctx, make_cmd, make_args):
     """Generates compilation database file for an arbitrary GNU Make command.
      Acts like a make wrapper, forwarding all MAKE_ARGS to make command"""
     make_cmd = make_cmd or 'make'
+    if os.uname().sysname == 'OpenBSD':
+        make_cmd = 'gmake'
     logging_mode_flags = "-Bnkw"
 
     options = ctx.obj


### PR DESCRIPTION
OpenBSD ships with BSD make which does not support the -w flag (among other flags). So in order to use compiledb, we will have to resort to ports. Luckily, GNU make is in ports but it is installed as `gmake`.